### PR TITLE
Add UTF-8 encoding to open of README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 from scraper import __version__
 
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
pip install -e .
fails on Windows with
    `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 7975:
 character maps to <undefined>`

